### PR TITLE
Security Update: bump urllib3 per Github vulnerability report

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ SQLAlchemy==1.4.14
 toml==0.10.2
 traitlets==5.0.5
 typing-extensions==3.10.0.0
-urllib3==1.26.4
+urllib3>=1.26.5
 wcwidth==0.2.5
 Werkzeug==1.0.1
 WTForms==2.3.3


### PR DESCRIPTION
Bumped `urllib3` version, as suggested by Github security alert.