### PR TITLE
Fix </div> tag order in `view-recipe-details.html` page

### DIFF
--- a/project/recipes/templates/recipes/view-recipe-details.html
+++ b/project/recipes/templates/recipes/view-recipe-details.html
@@ -66,9 +66,9 @@
       </div>
     </div>
   </div>
+  {% endif %}
 </div>
 
-{% endif %}
 <div class="accordion" id="accordionPanelsStayOpenExample">
   <div class="accordion-item">
     <h2 class="accordion-header" id="panelsStayOpen-headingOne">


### PR DESCRIPTION
Fixed a small issue with an incorrectly nested </div> tag in `view-recipe-details.html`