### PR TITLE
Revert to Gmail (temporarily)

### DIFF
--- a/config.py
+++ b/config.py
@@ -38,12 +38,12 @@ class ProductionConfig(Config):
     FLASK_ENV = 'production'
 
     # Flask Mail Config
-    MAIL_SERVER = 'smtp.sendgrid.net'
-    MAIL_PORT = 587
-    MAIL_USE_TLS = True
-    MAIL_USE_SSL = False
-    MAIL_USERNAME = 'apikey'
-    MAIL_PASSWORD = os.getenv('SENDGRID_API_KEY', default='')
+    # MAIL_SERVER = 'smtp.sendgrid.net'
+    # MAIL_PORT = 587
+    # MAIL_USE_TLS = True
+    # MAIL_USE_SSL = False
+    # MAIL_USERNAME = 'apikey'
+    # MAIL_PASSWORD = os.getenv('SENDGRID_API_KEY', default='')
 
 
 class DevelopmentConfig(Config):


### PR DESCRIPTION
Issue with SendGrid config on Heroku. This PR reverts to the same gmail config I used on dev, at least temporarily.