### PR TITLE
Enhancement: current user does not see recipe box on his/her own profile

### DIFF
--- a/project/users/templates/users/profile.html
+++ b/project/users/templates/users/profile.html
@@ -64,6 +64,7 @@
 
   </div>
 </div>
+{% if not user == current_user %}
 <div class="card mb-3 text-center">
   <div class="card-header">
     <h3 class="text-center">{{user_profile.username}}'s Recipes</h3>
@@ -76,5 +77,6 @@
   <p class="text-center">{{ user_profile.username }} has not liked any recipes yet.</p>
   {% endif %}
 </div>
+{% endif %}
 {% endblock %}
 </div>


### PR DESCRIPTION
This PR improves the current user's profile page experience. Before, when the current user went to his/her own profile page, a card with a an invitation to view his/her own recipe box would be displayed. That's been removed, because users can view their own recipe boxes from the user action menu in the navbar.